### PR TITLE
fix: update substitution timetable link

### DIFF
--- a/app/src/main/kotlin/me/tomasan7/jecnamobile/mainscreen/SidebarLink.kt
+++ b/app/src/main/kotlin/me/tomasan7/jecnamobile/mainscreen/SidebarLink.kt
@@ -17,7 +17,7 @@ enum class SidebarLink(
 )
 {
     SubstitutionTimetable(
-        "https://spsejecnacz.sharepoint.com/:x:/s/nastenka/EbA_RcWKRdRNlB8YU1iuWM4BnMetCQlVm8toHuuyW-TPyA?e=uu3iPR&CID=2686cea0-2d06-3304-4519-087fb9e06fd0",
+        "https://spsejecnacz.sharepoint.com/:x:/s/nastenka/ESy19K245Y9BouR5ksciMvgBu3Pn_9EaT0fpP8R6MrkEmg?e=9Vgl8M",
         R.string.sidebar_link_substitution_timetable,
         Icons.Outlined.TableChart
     ),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,7 +43,7 @@
 
     <string name="sidebar_link_substitution_timetable">Mimořádný rozvrh</string>
     <string name="sidebar_link_moodle">Moodle</string>
-    <string name="sidebar_link_jecna_web">Origiální stránky</string>
+    <string name="sidebar_link_jecna_web">Originální stránky</string>
 
     <!-- ##### News SubScreen ##### -->
 


### PR DESCRIPTION
Fixed to work with the new 2025/2026 school year, and fixed a typo.