### PR TITLE
feat(grades): support FinalGrade.Excused in Grades

### DIFF
--- a/app/src/main/kotlin/me/tomasan7/jecnamobile/grades/GradesSubScreen.kt
+++ b/app/src/main/kotlin/me/tomasan7/jecnamobile/grades/GradesSubScreen.kt
@@ -97,6 +97,7 @@ import me.tomasan7.jecnamobile.ui.component.VerticalSpacer
 import me.tomasan7.jecnamobile.ui.component.dashedBorder
 import me.tomasan7.jecnamobile.ui.component.rememberObjectDialogState
 import me.tomasan7.jecnamobile.ui.theme.grade_absence_warning
+import me.tomasan7.jecnamobile.ui.theme.grade_excused
 import me.tomasan7.jecnamobile.ui.theme.grade_grades_warning
 import me.tomasan7.jecnamobile.ui.theme.jm_label
 import me.tomasan7.jecnamobile.util.PullToRefreshHandler
@@ -441,7 +442,12 @@ private fun Subject(
                     FinalGrade(finalGrade = subject.finalGrade!!)
 
         },
-        onRightColumnClick = { showAverage = !showAverage }
+        onRightColumnClick = {
+            // Excused subject won't have any grades. This will throw NullPointerException if switched to showAwerage
+            if (subject.finalGrade !== FinalGrade.Excused) {
+                showAverage = !showAverage
+            }
+        }
     ) {
         if (subject.grades.isEmpty())
             Text(
@@ -815,6 +821,17 @@ private fun FinalGrade(
     is FinalGrade.GradesWarning           -> GradesWarning(onClick = onClick)
     is FinalGrade.AbsenceWarning          -> AbsenceWarning(onClick = onClick)
     is FinalGrade.GradesAndAbsenceWarning -> GradesAndAbsenceWarning(onClick = onClick)
+    is FinalGrade.Excused                 -> Excused(onClick = onClick)
+}
+
+@Composable
+private fun Excused(onClick: (() -> Unit)? = {})
+{
+    GradeBox(
+        text = stringResource(R.string.grade_excused),
+        color = grade_excused,
+        onClick = onClick
+    )
 }
 
 

--- a/app/src/main/kotlin/me/tomasan7/jecnamobile/ui/theme/Color.kt
+++ b/app/src/main/kotlin/me/tomasan7/jecnamobile/ui/theme/Color.kt
@@ -82,6 +82,7 @@ val grade_3 = Color(0xFFBEDB00)
 val grade_4 = Color(0xFFCFA200)
 val grade_5 = Color(0xFFA63232)
 
+val grade_excused = Color(0xFF757474)
 val grade_grades_warning = Color(0xFFFF8A8A)
 val grade_absence_warning = Color(0xFFFF8A8A)
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,6 +69,7 @@
 
     <string name="grade_grades_warning_content">5?</string>
     <string name="grade_absence_warning_content">N?</string>
+    <string name="grade_excused">U</string>
 
     <string name="grade_weight">Váha</string>
     <string name="grade_weight_small">Malá</string>


### PR DESCRIPTION
Update UI to handle excused final grades. This reflects changes in JecnaAPI in https://github.com/tomhula/JecnaAPI/pull/3.

- Add `Excused` composable.

---

<img src="https://github.com/user-attachments/assets/e44818a8-9cd5-48fd-8525-ff8705d06359" width="300" />
