### PR TITLE
fix: Replace FlowRow with custom FlowRow

### DIFF
--- a/app/src/main/kotlin/me/tomasan7/jecnamobile/attendances/AttendancesSubScreen.kt
+++ b/app/src/main/kotlin/me/tomasan7/jecnamobile/attendances/AttendancesSubScreen.kt
@@ -166,9 +166,9 @@ private fun AttendancesDay(
         modifier = modifier
     ) {
         FlowRow(
-            Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(7.dp),
-            verticalArrangement = Arrangement.spacedBy(7.dp)
+            modifier = Modifier.fillMaxWidth(),
+            horizontalSpacing = 7.dp,
+            verticalSpacing = 7.dp
         ) {
             attendanceRow.second.forEach { attendance ->
                 AttendanceChip(attendance)

--- a/app/src/main/kotlin/me/tomasan7/jecnamobile/grades/GradesSubScreen.kt
+++ b/app/src/main/kotlin/me/tomasan7/jecnamobile/grades/GradesSubScreen.kt
@@ -83,6 +83,7 @@ import me.tomasan7.jecnamobile.mainscreen.SubScreensNavGraph
 import me.tomasan7.jecnamobile.settings.Settings
 import me.tomasan7.jecnamobile.ui.ElevationLevel
 import me.tomasan7.jecnamobile.ui.component.DialogRow
+import me.tomasan7.jecnamobile.ui.component.FlowRow
 import me.tomasan7.jecnamobile.ui.component.HorizontalSpacer
 import me.tomasan7.jecnamobile.ui.component.ObjectDialog
 import me.tomasan7.jecnamobile.ui.component.OfflineDataIndicator

--- a/app/src/main/kotlin/me/tomasan7/jecnamobile/ui/component/FlowRow.kt
+++ b/app/src/main/kotlin/me/tomasan7/jecnamobile/ui/component/FlowRow.kt
@@ -1,4 +1,4 @@
-package me.tomasan7.jecnamobile.grades
+package me.tomasan7.jecnamobile.ui.component
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable


### PR DESCRIPTION
Well this fixes the bug with the `FlowRow` not calculating the height properly. I just wrote my own basic implementation of FlowRow. Just basic "if fits on the row keep it on that row, else create new row and put it there".

I had to also implement `minIntrinsicHeight`. Without the custom minIntrinsicHeight implementation, Compose doesn't run full layout() logic to check how tall should the FlowRow be. Instead, it estimates. It estimated the "worst-case scenario", assuming every item might need its own row. So basically my `FlowRow` would render correctly but parent components wouldn't set its height according the the `FlowRow`.

This could be also fixed by removing the `Modifier.height(IntrinsicSize.Min)` from the `Container` composable, but this would break the whole layout (missing the line and the final grade wouldn't be centered vertically. I think this is what _Stevekk_ did in his implementation.

---

Technically this implementation is fully working and production-ready, but I think the code could be improved. I just wanted to give you some "base" and working example so you can tweak it how you want. 

This has been tested on multiple devices and on multiple accounts. ~~Technically you could use this implementation for Grades too but rn `align` in the `Modifier` isn't implemented and I couldn't be bothered to implement it if grades work. I just wanted the Behaviour notifications to finally work.~~ **It is used in grades now too!**