### PR TITLE
fix: Read auth in canteen from proper place when remember me not set

### DIFF
--- a/app/src/main/kotlin/me/tomasan7/jecnamobile/canteen/CanteenViewModel.kt
+++ b/app/src/main/kotlin/me/tomasan7/jecnamobile/canteen/CanteenViewModel.kt
@@ -15,7 +15,9 @@ import de.palm.composestateevents.StateEventWithContent
 import de.palm.composestateevents.consumed
 import de.palm.composestateevents.triggered
 import io.github.tomhula.jecnaapi.CanteenClient
+import io.github.tomhula.jecnaapi.JecnaClient
 import io.github.tomhula.jecnaapi.WebCanteenClient
+import io.github.tomhula.jecnaapi.WebJecnaClient
 import io.github.tomhula.jecnaapi.data.canteen.DayMenu
 import io.github.tomhula.jecnaapi.data.canteen.ExchangeItem
 import io.github.tomhula.jecnaapi.data.canteen.MenuItem
@@ -45,6 +47,7 @@ class CanteenViewModel @Inject constructor(
     @ApplicationContext
     private val appContext: Context,
     private val authRepository: AuthRepository,
+    private val jecnaClient: JecnaClient,
     private val canteenClient: CanteenClient,
 ) : ViewModel()
 {
@@ -76,7 +79,8 @@ class CanteenViewModel @Inject constructor(
         loginJob = viewModelScope.launch {
             changeUiState(loading = true)
 
-            val auth = authRepository.get()
+            // Auth repository is required because when user has Jidelna set as defualt page, the autoLoginAuth in jecnaClient isn't set yet.
+            val auth = (jecnaClient as WebJecnaClient).autoLoginAuth ?: authRepository.get()
 
             if (auth != null)
                 try


### PR DESCRIPTION
It would be probably nice to also remove the issue from README. As well as with the clicking notifications. I think this was fixed too already, no?

fixed #23 