### PR TITLE
News image fix

### DIFF
--- a/app/src/main/kotlin/me/tomasan7/jecnamobile/news/NewsViewModel.kt
+++ b/app/src/main/kotlin/me/tomasan7/jecnamobile/news/NewsViewModel.kt
@@ -104,7 +104,6 @@ class NewsViewModel @Inject constructor(
 
             val sessionCookie = getSessionCookie() ?: return@launch
             addRequestHeader("Cookie", sessionCookie.toHeaderString())
-            addRequestHeader("Accept-Language", "en-US,en;q=0.9")
         }
 
         downloadManager.enqueue(request)


### PR DESCRIPTION
Add's valid browser-based `User-Agent` and `Accept-Language` headers to News image fetching.

This fixes #48