### PR TITLE
fix: Move the JecnaMobilePullToRefreshBox under Tabs in canteen

### DIFF
--- a/app/src/main/kotlin/me/tomasan7/jecnamobile/canteen/CanteenSubScreen.kt
+++ b/app/src/main/kotlin/me/tomasan7/jecnamobile/canteen/CanteenSubScreen.kt
@@ -138,7 +138,8 @@ fun CanteenSubScreen(
                 modifier = Modifier.fillMaxSize()
             ) {
                 Box(
-                    modifier = Modifier.fillMaxSize()
+                    modifier = Modifier
+                        .fillMaxSize()
                 ) {
                     when (selectedTabIndex)
                     {


### PR DESCRIPTION
Fixed the indicator in the canteen as requested