### PR TITLE
feat: Indicator drag from middle

### DIFF
--- a/app/src/main/kotlin/me/tomasan7/jecnamobile/ui/component/LinearPullToRefreshBox.kt
+++ b/app/src/main/kotlin/me/tomasan7/jecnamobile/ui/component/LinearPullToRefreshBox.kt
@@ -12,7 +12,11 @@ import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.layout
 import kotlin.math.pow
+import kotlin.math.roundToInt
 
 @Composable
 fun LinearPullToRefreshBox(
@@ -60,8 +64,12 @@ private fun LinearIndicator(
         else if (state.distanceFraction != 0f)
             LinearProgressIndicator(
                 drawStopIndicator = {},
-                progress = { easeInOutQuint(state.distanceFraction) },
-                modifier = Modifier.fillMaxWidth()
+                progress = { 1f },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .graphicsLayer {
+                        scaleX = easeInOutQuint(state.distanceFraction).coerceIn(0f, 1f)
+                    }
             )
     }
 }


### PR DESCRIPTION
Note that this will not round the element, tbh I don't feel like that's really that important. If you really wanted that we would have to create our own canvas and draw it manually or use .layout but that would be expensive.

I think this is the sweet middle-ground. Ngl the more I used the app that had the animation from the left the more I hated it idk why.