### PR TITLE
feat: Announcements in substitutions

### DIFF
--- a/app/src/main/kotlin/me/tomasan7/jecnamobile/substitutions/SubstitutionSubScreen.kt
+++ b/app/src/main/kotlin/me/tomasan7/jecnamobile/substitutions/SubstitutionSubScreen.kt
@@ -146,6 +146,16 @@ fun SubstitutionSubScreen(
                         )
                     }
 
+                    uiState.selectedDate?.let { selectedDate ->
+                        if (uiState.data.announcements.isNotEmpty()) {
+                            AnnouncementsSection(
+                                announcements = uiState.data.announcements,
+                                modifier = Modifier.fillMaxWidth(),
+                                targetDate = kotlinx.datetime.LocalDate.parse(selectedDate.date.toString())
+                            )
+                        }
+                    }
+
                     val selectedDayData = uiState.data.schedule[uiState.selectedDate?.key]
                     if (selectedDayData != null)
                     {

--- a/app/src/main/kotlin/me/tomasan7/jecnamobile/timetable/TimetableData.kt
+++ b/app/src/main/kotlin/me/tomasan7/jecnamobile/timetable/TimetableData.kt
@@ -5,6 +5,8 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import cz.jzitnik.jecna_supl_client.AbsenceEntry as JecnaAbsenceEntry
 import cz.jzitnik.jecna_supl_client.ApiResponse as JecnaApiResponse
+import cz.jzitnik.jecna_supl_client.Announcement as JecnaAnnouncement
+import cz.jzitnik.jecna_supl_client.AnnouncementFlag as JecnaAnnouncementFlag
 import cz.jzitnik.jecna_supl_client.ChangeEntry as JecnaChangeEntry
 import cz.jzitnik.jecna_supl_client.DailyData as JecnaDailyData
 import cz.jzitnik.jecna_supl_client.DailySchedule as JecnaDailySchedule
@@ -19,7 +21,8 @@ data class TimetableData(
 data class SubstitutionAllData(
     val lastUpdated: String,
     val currentUpdateSchedule: Int,
-    val schedule: Map<String, GlobalDailyData>
+    val schedule: Map<String, GlobalDailyData>,
+    val announcements: Map<String, List<Announcement>> = emptyMap()
 )
 
 @Serializable
@@ -111,10 +114,33 @@ data class SubstituteInfo(
     val teacherCode: String
 )
 
+@Serializable
+data class Announcement(
+    val id: Int,
+    val author: String,
+    val createdAt: String,
+    val startDate: String,
+    val endDate: String,
+    val textContent: String?,
+    val flags: List<AnnouncementFlag>
+)
+
+@Serializable
+sealed class AnnouncementFlag {
+    @Serializable
+    @SerialName("SHOW_ALL_ENTRIES")
+    data object ShowAllEntries : AnnouncementFlag()
+
+    @Serializable
+    @SerialName("Unknown")
+    data class Unknown(val v1: String) : AnnouncementFlag()
+}
+
 fun JecnaApiResponse.toSubstitutionAllData() = SubstitutionAllData(
     lastUpdated = status.lastUpdated,
     currentUpdateSchedule = status.currentUpdateSchedule.toInt(),
-    schedule = schedule.mapValues { it.value.toGlobalDailyData() }
+    schedule = schedule.mapValues { it.value.toGlobalDailyData() },
+    announcements = announcements.mapValues { it.value.map { a -> a.toAnnouncement() } }
 )
 
 fun JecnaDailyData.toGlobalDailyData() = GlobalDailyData(
@@ -139,6 +165,21 @@ fun JecnaChangeEntry.toChangeEntry() = ChangeEntry(
     willBeSpecified = willBeSpecified
 )
 
+fun JecnaAnnouncementFlag.toAnnouncementFlag(): AnnouncementFlag = when (this) {
+    is JecnaAnnouncementFlag.ShowAllEntries -> AnnouncementFlag.ShowAllEntries
+    is JecnaAnnouncementFlag.Unknown -> AnnouncementFlag.Unknown(v1)
+}
+
+fun JecnaAnnouncement.toAnnouncement() = Announcement(
+    id = id,
+    author = author,
+    createdAt = createdAt,
+    startDate = startDate,
+    endDate = endDate,
+    textContent = textContent,
+    flags = flags.map { it.toAnnouncementFlag() }
+)
+
 fun JecnaAbsenceEntry.toAbsenceEntry(): AbsenceEntry = when (this) {
     is JecnaAbsenceEntry.WholeDay -> AbsenceEntry.WholeDay(teacher, teacherCode)
     is JecnaAbsenceEntry.Single -> AbsenceEntry.Single(teacher, teacherCode, hours.toInt())
@@ -153,4 +194,5 @@ data class SubstitutionData(
     val lastUpdated: String,
     val currentUpdateSchedule: Int,
     val data: List<DailySchedule> = emptyList(),
+    val announcements: Map<String, List<Announcement>>? = null
 )

--- a/app/src/main/kotlin/me/tomasan7/jecnamobile/timetable/TimetableRepositoryImpl.kt
+++ b/app/src/main/kotlin/me/tomasan7/jecnamobile/timetable/TimetableRepositoryImpl.kt
@@ -66,9 +66,10 @@ class TimetableRepositoryImpl(
             substitutionClient.getSchedule(className)
         }
         return SubstitutionData(
-            subs.status.lastUpdated,
-            subs.status.currentUpdateSchedule.toInt(),
-            subs.schedule.map { (date, schedule) -> schedule.toDailySchedule(date) }
+            lastUpdated = subs.status.lastUpdated,
+            currentUpdateSchedule = subs.status.currentUpdateSchedule.toInt(),
+            data = subs.schedule.map { (date, schedule) -> schedule.toDailySchedule(date) },
+            announcements = subs.annoucements.mapValues { it.value.map { a -> a.toAnnouncement() } }
         )
     }
 

--- a/app/src/main/kotlin/me/tomasan7/jecnamobile/timetable/TimetableSubScreen.kt
+++ b/app/src/main/kotlin/me/tomasan7/jecnamobile/timetable/TimetableSubScreen.kt
@@ -237,6 +237,15 @@ fun TimetableSubScreen(
                                     end = 8.dp,
                                     bottom = if (takesPlaceText != null) 8.dp else 0.dp
                                 )
+
+                                uiState.substitutions.announcements?.let {
+                                    AnnouncementsSection(
+                                        announcements = it,
+                                        modifier = Modifier.fillMaxWidth(),
+                                        targetDate = targetDate
+                                    )
+                                }
+                                
                                 ExpandableSection(
                                     title = stringResource(R.string.sidebar_link_substitution_timetable),
                                     modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/kotlin/me/tomasan7/jecnamobile/ui/component/AnnouncementsSection.kt
+++ b/app/src/main/kotlin/me/tomasan7/jecnamobile/ui/component/AnnouncementsSection.kt
@@ -1,0 +1,124 @@
+package me.tomasan7.jecnamobile.ui.component
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import kotlinx.datetime.LocalDate
+import me.tomasan7.jecnamobile.R
+import me.tomasan7.jecnamobile.timetable.Announcement
+import java.time.format.DateTimeFormatter
+import java.time.LocalDate as JavaLocalDate
+
+@Composable
+fun AnnouncementsSection(
+    announcements: Map<String, List<Announcement>>,
+    modifier: Modifier = Modifier,
+    targetDate: LocalDate? = null
+)
+{
+    val visibleAnnouncements = remember(targetDate, announcements) {
+        if (targetDate != null)
+            announcements[targetDate.toString()]
+                ?.filter { it.textContent != null }
+                .orEmpty()
+        else
+            announcements.values.flatten().filter { it.textContent != null }
+    }
+
+    if (visibleAnnouncements.isEmpty())
+        return
+
+    ExpandableSection(
+        title = stringResource(R.string.announcements_title),
+        modifier = modifier,
+        icon = { Icon(Icons.Default.Info, contentDescription = null, modifier = Modifier.size(20.dp)) },
+        initiallyExpanded = true
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            visibleAnnouncements.forEach { announcement ->
+                AnnouncementCard(announcement = announcement)
+            }
+        }
+    }
+}
+
+private val DATE_FORMATTER = DateTimeFormatter.ofPattern("d.M.yyyy")
+private val DATE_ICON_SIZE = 16.dp
+private const val ICON_ALPHA = 0.6f
+
+@Composable
+private fun AnnouncementCard(
+    announcement: Announcement,
+    modifier: Modifier = Modifier
+)
+{
+    val dateText = remember(announcement.startDate, announcement.endDate) {
+        val start = runCatching { JavaLocalDate.parse(announcement.startDate) }.getOrNull()
+        val end = runCatching { JavaLocalDate.parse(announcement.endDate) }.getOrNull()
+        if (start != null && end != null)
+        {
+            if (start != end)
+                "${start.format(DATE_FORMATTER)} - ${end.format(DATE_FORMATTER)}"
+            else
+                start.format(DATE_FORMATTER)
+        }
+        else
+            null
+    }
+
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.tertiaryContainer),
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Person,
+                    contentDescription = null,
+                    modifier = Modifier.size(DATE_ICON_SIZE),
+                    tint = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = ICON_ALPHA)
+                )
+                Spacer(Modifier.width(4.dp))
+                Text(
+                    text = announcement.author,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.7f)
+                )
+                Spacer(Modifier.weight(1f))
+                if (dateText != null)
+                {
+                    Icon(
+                        imageVector = Icons.Default.DateRange,
+                        contentDescription = null,
+                        modifier = Modifier.size(DATE_ICON_SIZE),
+                        tint = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = ICON_ALPHA)
+                    )
+                    Spacer(Modifier.width(4.dp))
+                    Text(
+                        text = dateText,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.7f)
+                    )
+                }
+            }
+            Spacer(Modifier.height(6.dp))
+            Text(
+                text = announcement.textContent!!,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onTertiaryContainer
+            )
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,6 +58,7 @@
     <string name="substitution_day_info_tomorrow">Koná se zítra</string>
     <string name="substitution_day_info_monday">Koná se v pondělí</string>
     <string name="substitution_will_be_specified">(bude upřesněno)</string>
+    <string name="announcements_title">Oznámení mimořádného rozvrhu</string>
 
     <!-- ##### Main Screen ##### -->
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ plugin-kotlin = "2.3.20"
 plugin-ksp = "2.3.6"
 
 jecnaAPI = "10.3.0"
-jecnaSupl = "0.2.3"
+jecnaSupl = "0.3.2"
 jna = "5.18.1"
 
 compose-android-bom = "2026.05.01"


### PR DESCRIPTION
Fully implemented new announcements API in the Substitution API.

It is used for global announcements about the parser. For example about known issue that might confused the class about some change, that won't be fixed or something.

There are global announcements (for all classes) and class specific announcements. This filtering is handled in the jecna_supl_client lib.

---

<img width="300" alt="Screenshot_20260602_175716_Jen Mobile Debug" src="https://github.com/user-attachments/assets/2985ca8b-156c-4e3f-9ff8-da5519f711eb" />

