### PR TITLE
fix: Fix timetable when vedení removes period

### DIFF
--- a/app/src/main/kotlin/me/tomasan7/jecnamobile/timetable/TimetableCacheRepository.kt
+++ b/app/src/main/kotlin/me/tomasan7/jecnamobile/timetable/TimetableCacheRepository.kt
@@ -35,9 +35,12 @@ class TimetableCacheRepository(
             return entireCache[params]
         
         val schoolYearTimetables = entireCache.filterKeys { it.schoolYear == params.schoolYear }
-        val mostRecentOne = schoolYearTimetables.maxByOrNull { entry ->
-            entry.value.data.page.periodOptions.find { it.selected }!!.from
-        }?.value ?: return null
+        
+        val maxFrom = schoolYearTimetables.maxOf { it.value.data.page.periodOptions.find { it.selected }!!.from }
+        val mostRecentOne = schoolYearTimetables
+            .filter { it.value.data.page.periodOptions.find { it.selected }!!.from == maxFrom }
+            .maxByOrNull { it.value.timestamp }
+            ?.value
         
         return mostRecentOne
     }


### PR DESCRIPTION
When vedení removed a timetable period (id 210) it was still stored in cache and the newer period never won as the new newest period so the id 210 was never overwritten by the new id 211. This fixes this issue.